### PR TITLE
Update PlayerStatsCommands.java to fix removeattributepoints subcommand

### DIFF
--- a/src/main/java/com/playerstats/command/PlayerStatsCommands.java
+++ b/src/main/java/com/playerstats/command/PlayerStatsCommands.java
@@ -36,7 +36,7 @@ public class PlayerStatsCommands {
                                     int amount = IntegerArgumentType.getInteger(ctx, "amount");
                                     int current = PlayerAttributePersistence.getPoints(player);
 
-                                    PlayerAttributePersistence.addAbilityPoints(player, -amount);
+                                    PlayerAttributePersistence.addPoints(player, -amount);
                                     ctx.getSource().sendSuccess(() ->
                                             net.minecraft.network.chat.Component.translatable("gui.playerstats.removed_points", current - amount), false);
                                     return 1;


### PR DESCRIPTION
I simply wanted this fixed. I'm so lazy that I'm not even using actual git bash or stuff, I'm just editing on github.com

Subcommand removeattributepoints should call `addPoints` instead of `addAbilityPoints` (assuming adding negative value doesn't break everything).